### PR TITLE
chore: update to libdns/libdns v0.2.2 - fix build errors with caddy v2.8.0+

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/libdns/easydns
 
 go 1.20
 
-require github.com/libdns/libdns v0.2.1
+require github.com/libdns/libdns v0.2.2

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/libdns/libdns v0.2.1 h1:Wu59T7wSHRgtA0cfxC+n1c/e+O3upJGWytknkmFEDis=
-github.com/libdns/libdns v0.2.1/go.mod h1:yQCXzk1lEZmmCPa857bnk4TsOiqYasqpyOEeSObbb40=
+github.com/libdns/libdns v0.2.2 h1:O6ws7bAfRPaBsgAYt8MDe2HcNBGC29hkZ9MX2eUSX3s=
+github.com/libdns/libdns v0.2.2/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=

--- a/provider.go
+++ b/provider.go
@@ -114,7 +114,7 @@ func (p *Provider) AppendRecords(ctx context.Context, zone string, records []lib
 			Domain:   zone,
 			Host:     record.Name,
 			TTL:      int(record.TTL.Seconds()),
-			Priority: record.Priority,
+			Priority: int(record.Priority),
 			Type:     record.Type,
 			Rdata:    record.Value,
 		})

--- a/provider.go
+++ b/provider.go
@@ -78,7 +78,7 @@ func (p *Provider) GetRecords(ctx context.Context, zone string) ([]libdns.Record
 		if err != nil {
 			return nil, err
 		}
-		priority, err := strconv.Atoi(r.Priority)
+		uint(priority), err := strconv.Atoi(r.Priority)
 		if err != nil {
 			priority = 0
 		}
@@ -88,7 +88,7 @@ func (p *Provider) GetRecords(ctx context.Context, zone string) ([]libdns.Record
 			Name:     r.Host,
 			Value:    r.Rdata,
 			TTL:      time.Duration(ttl) * time.Second,
-			Priority: priority,
+			Priority: int(priority),
 		})
 	}
 

--- a/provider.go
+++ b/provider.go
@@ -78,7 +78,7 @@ func (p *Provider) GetRecords(ctx context.Context, zone string) ([]libdns.Record
 		if err != nil {
 			return nil, err
 		}
-		uint(priority), err := strconv.Atoi(r.Priority)
+		priority, err := strconv.Atoi(r.Priority)
 		if err != nil {
 			priority = 0
 		}
@@ -88,7 +88,7 @@ func (p *Provider) GetRecords(ctx context.Context, zone string) ([]libdns.Record
 			Name:     r.Host,
 			Value:    r.Rdata,
 			TTL:      time.Duration(ttl) * time.Second,
-			Priority: int(priority),
+			Priority: uint(priority),
 		})
 	}
 


### PR DESCRIPTION
Compare to:
https://github.com/libdns/netcup/pull/1
https://github.com/caddy-dns/netcup/pull/6