### PR TITLE
Updated libdns to v1.1.0

### DIFF
--- a/_example/main.go
+++ b/_example/main.go
@@ -49,11 +49,11 @@ func main() {
 
 	testName := "_acme-challenge.home"
 	hasTestName := false
-	var testRecord libdns.Record = libdns.Record{}
+	var testRecord libdns.Record = libdns.RR{}
 
 	for _, record := range records {
-		fmt.Printf("%s (.%s): %s, %s\n", record.Name, zone, record.Value, record.Type)
-		if record.Name == testName {
+		fmt.Printf("%s (.%s): %s, %s\n", record.RR().Name, zone, record.RR().Data, record.RR().Type)
+		if record.RR().Name == testName {
 			hasTestName = true
 			testRecord = record
 		}
@@ -61,11 +61,11 @@ func main() {
 
 	if !hasTestName {
 		appendedRecords, err := provider.AppendRecords(context.TODO(), zone, []libdns.Record{
-			libdns.Record{
-				Type:  "TXT",
-				Name:  testName,
-				TTL:   0,
-				Value: "test_add_record_value",
+			libdns.RR{
+				Type: "TXT",
+				Name: testName,
+				TTL:  0,
+				Data: "test_add_record_value",
 			},
 		})
 
@@ -75,8 +75,9 @@ func main() {
 
 		fmt.Println("appendedRecords")
 		fmt.Println(appendedRecords)
-	} else if testRecord.Value == "test_add_record_value" {
-		testRecord.Value = "test_update_record_value"
+	} else if testRecord.RR().Data == "test_add_record_value" {
+		testRecord := testRecord.RR()
+		testRecord.Data = "test_update_record_value"
 		updatedRecords, err := provider.SetRecords(context.TODO(), zone, []libdns.Record{
 			testRecord,
 		})

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/libdns/easydns
 
-go 1.20
+go 1.24
 
-require github.com/libdns/libdns v0.2.2
+require github.com/libdns/libdns v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
-github.com/libdns/libdns v0.2.2 h1:O6ws7bAfRPaBsgAYt8MDe2HcNBGC29hkZ9MX2eUSX3s=
-github.com/libdns/libdns v0.2.2/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
+github.com/libdns/libdns v1.1.0 h1:9ze/tWvt7Df6sbhOJRB8jT33GHEHpEQXdtkE3hPthbU=
+github.com/libdns/libdns v1.1.0/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=

--- a/models.go
+++ b/models.go
@@ -1,5 +1,7 @@
 package easydns
 
+import "github.com/libdns/libdns"
+
 // ZoneRecordResponse is the response from the EasyDNS API for a zone record request.
 type ZoneRecordResponse struct {
 	Timestamp int `json:"tm,omitempty"` // Result Timestamp
@@ -36,4 +38,15 @@ type UpdateEntry struct {
 	TTL   int    `json:"ttl,omitempty"`
 	Type  string `json:"type,omitempty"`
 	Rdata string `json:"rdata,omitempty"`
+}
+
+// DNS custom struct that implements the libdns.Record interface
+type DnsRecord struct {
+	Id     string
+	Record libdns.RR
+}
+
+// Function that implements RR function for custom DnsRecord struct
+func (dnsRecord DnsRecord) RR() libdns.RR {
+	return dnsRecord.Record
 }


### PR DESCRIPTION
Can a tag labelled `v1.1.0` also be created for this codebase?
Once done, I can create a pull request for the caddy-dns [plugin](https://github.com/caddy-dns/easydns) and easydns should then work with caddy v2.10.